### PR TITLE
Correct data sending interval and DynamoDB key

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -12,7 +12,7 @@ export const handler = async (event) => {
       const command = new PutCommand({
         TableName: 'IoTMonitoringGardenMetrics',
         Item: {
-          GardenId: garden.id,
+          GardenID: garden.id,
           Timestamp: new Date(garden.timestamp * 1000).toISOString(),
           Temperature: garden.temperature,
           Humidity: garden.humidity,

--- a/esp32/code.ino
+++ b/esp32/code.ino
@@ -10,7 +10,7 @@
 #define SENSOR_HUMIDITY_ONE_PIN 33
 #define SENSOR_HUMIDITY_TWO_PIN 32
 
-#define DATA_SEND_INTERVAL_MS 1000 * 60 // 1 hour 
+#define DATA_SEND_INTERVAL_MS 1000 * 60 * 60 // 1 hour 
 
 #define AWS_IOT_DATA_TOPIC "iot/esp32/garden/monitoring"
 


### PR DESCRIPTION
Inadvertently multiplied the data sending interval by 60 only once instead of twice, resulting in incorrect time values. Also, corrected the DynamoDB key from GardenId to GardenID for consistency.

Changes:
- Updated DATA_SEND_INTERVAL_MS to correctly represent 1 hour: #define DATA_SEND_INTERVAL_MS 1000 * 60 * 60
- Fixed DynamoDB key from GardenId to GardenID for proper naming.